### PR TITLE
Details field now has limited length

### DIFF
--- a/discordrp_mpris/config/config.toml
+++ b/discordrp_mpris/config/config.toml
@@ -16,6 +16,8 @@ show_stopped = false
 show_time = "elapsed"
 # Whether to ignore a player. Supposed to be overridden.
 ignore = false
+# Maximum number of bytes in the title field
+max_title_len = 64
 
 # You can override any of the [options] options
 # for each player individually.


### PR DESCRIPTION
Using textwrap.shorten

- details limited to 128 characters
- artists field has configurable length (max_artist_len)
- title field has configurable length (max_title_len)

I'm not experienced with Python so this might be far from ideal.

Fixes #20 