### PR TITLE
Remove loop parameter from asyncio calls

### DIFF
--- a/discord_rpc/async_.py
+++ b/discord_rpc/async_.py
@@ -213,7 +213,7 @@ class UnixAsyncDiscordRpc(AsyncDiscordRpc):
             logger.debug("Attempting to connecting to %r", path)
             try:
                 self.reader, self.writer = \
-                    await asyncio.open_unix_connection(path, loop=self.loop)
+                    await asyncio.open_unix_connection(path)
             except OSError as e:
                 logger.error("failed to open {!r}: {}".format(path, e))
             else:

--- a/discordrp_mpris/__main__.py
+++ b/discordrp_mpris/__main__.py
@@ -287,7 +287,7 @@ def main() -> int:
         return loop.run_until_complete(main_task)
     except BaseException as e:
         main_task.cancel()
-        wait_task = asyncio.wait_for(main_task, 5, loop=loop)
+        wait_task = asyncio.wait_for(main_task, 5)
         try:
             loop.run_until_complete(wait_task)
         except asyncio.CancelledError:


### PR DESCRIPTION
Was apparently removed in Python 3.10, not sure if it did something important